### PR TITLE
Fix broken bash if-else

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -5,7 +5,7 @@ if [ -z $1 ]; then
   echo "Input the url of your cluster. Example:"
   echo "name.us-west-1.elb.amazonaws.com"
   echo ""
-elif [ ! -z $1 ]; then
+else
   bash ./install.sh . $1
 
   echo "Setup complete."


### PR DESCRIPTION
elif has to be replaced by else thats better. the check on $1 is already performed in`if`, so only `else` would be used for desired action :)
